### PR TITLE
Update originating dfi id

### DIFF
--- a/check_run/check_run/doctype/check_run/check_run.py
+++ b/check_run/check_run/doctype/check_run/check_run.py
@@ -724,7 +724,7 @@ def build_nacha_file_from_payment_entries(doc, payment_entries, settings):
 		effective_entry_date=doc.posting_date,
 		settlement_date=None,
 		originator_status_code=1,
-		originating_dfi_id=company_bank_account_no,
+		originating_dfi_id=company_bank_aba_number,
 		entries=ach_entries,
 	)
 	nacha_file = NACHAFile(


### PR DESCRIPTION
According to the NACHA Dev Guide, Originating DFI Identification is supposed to be "The routing number of the DFI originating the entries within the batch."